### PR TITLE
Fix minimax

### DIFF
--- a/app/config/gameLogicSingleplayer.js
+++ b/app/config/gameLogicSingleplayer.js
@@ -89,6 +89,13 @@ export function checkWin(array) {
         }
     }
 
+    if (checkDraw(array)) {
+        return  {
+            winNum: -1,
+            winner: 'tie'
+        };
+    }
+
     return {
         winNum: -1,
         winner: null

--- a/app/config/miniMax.js
+++ b/app/config/miniMax.js
@@ -5,7 +5,7 @@ import { copyArray } from './copyArray';
  * Returns the best move for the AI to play 
  */
 export function bestMove(boardRecieved) {
-    board = copyArray(boardRecieved);
+    const board = copyArray(boardRecieved);
     console.log(board);
     let bestScore = -Infinity;
     let move;
@@ -42,7 +42,7 @@ let scores = {
  */
 function minimax(board, ai, depth) {
     const win = checkWin(board);
-    if (checkWin(board).winNum > 0) {
+    if (win.winner) {
         return scores[win.winner];
     }
     // If ai is playing - we want highest score


### PR DESCRIPTION
# Motivation

The existing code doesn't check for ties.

This was causing the minimax algo to assume that all routes which did not lead to wins instead lead to losses. Regardless of what X plays, O can at best attain a draw and at worst lose. So the algorithm was assuming that all O moves were losses (equally bad) and returned the first move tried (which in many cases was an actual loss).

# Changes

- Added check for draw in `checkWin`
- Changed `minimax` to look at `winner` rather than `winNum`: I made the draw return `winNum: -1` so checking the `winNum` would not work. But `winner: null` is true if and only if the game should continue.

# Testing

Ran this code and verified the correct scores were being printed:

```js
console.log(
  bestMove(
    [['-', 'X', '-'],
     ['-', '-', '-'],
     ['-', '-', '-']]
  )
);
```

Really, this should have automated testing. But there's no framework for that right now so I didn't add any automated tests.